### PR TITLE
openscad: rebuild fix

### DIFF
--- a/mingw-w64-openscad/001-openscad-2021-libintl-collisions.patch
+++ b/mingw-w64-openscad/001-openscad-2021-libintl-collisions.patch
@@ -1,0 +1,22 @@
+diff --git a/src/printutils.h b/src/printutils.h
+index 5f887f0ef..0bb021eb4 100644
+--- a/src/printutils.h
++++ b/src/printutils.h
+@@ -6,8 +6,17 @@
+ #include <boost/format.hpp>
+ #include <boost/algorithm/string.hpp>
+ #include <utility>
++
+ #include <libintl.h>
++// Undefine some defines from libintl.h to presolve
++// some collisions in boost headers later
++#if defined snprintf
+ #undef snprintf
++#endif
++#if defined vsnprintf
++#undef vsnprintf
++#endif
++
+ #include <locale.h>
+ #include "AST.h"
+ #include <set>

--- a/mingw-w64-openscad/PKGBUILD
+++ b/mingw-w64-openscad/PKGBUILD
@@ -31,11 +31,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-eigen3"
              "${MINGW_PACKAGE_PREFIX}-imagemagick")
 options=(!strip staticlibs)
-source=("https://files.openscad.org/${_realname}-${pkgver}.src.tar.gz")
-sha256sums=('d938c297e7e5f65dbab1461cac472fc60dfeaa4999ea2c19b31a4184f2d70359')
+source=("https://files.openscad.org/${_realname}-${pkgver}.src.tar.gz"
+        '001-openscad-2021-libintl-collisions.patch')
+sha256sums=('d938c297e7e5f65dbab1461cac472fc60dfeaa4999ea2c19b31a4184f2d70359'
+            'f295d41896cc55f6645e080e527ba3d033357bc744b7f7bb01b9271974ee930e')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/001-openscad-2021-libintl-collisions.patch"
   #rm -f libraries/MCAD/*.py
 }
 


### PR DESCRIPTION
This fix can help with https://github.com/msys2/MINGW-packages/pull/9612.
Please also review https://github.com/msys2/MINGW-packages-dev/pull/20.